### PR TITLE
fix: Change type of cause to unknown.

### DIFF
--- a/lib/CustomError.ts
+++ b/lib/CustomError.ts
@@ -2,6 +2,6 @@ export interface CustomError extends Error {
   name: string;
   code: string;
   message: string;
-  cause?: Error;
+  cause?: unknown;
   data?: any;
 }

--- a/lib/ErrorConstructors.ts
+++ b/lib/ErrorConstructors.ts
@@ -2,7 +2,7 @@ import { CustomError } from './CustomError';
 
 interface ErrorConstructor {
   new(message?: string, { cause, data }?: {
-    cause?: Error;
+    cause?: unknown;
     data?: any;
   }): CustomError;
 

--- a/lib/defekt.ts
+++ b/lib/defekt.ts
@@ -19,7 +19,7 @@ const defekt = function <TErrorDefinition extends Record<string, { code?: string
 
       public message: string;
 
-      public cause?: Error;
+      public cause?: unknown;
 
       public data?: any;
 
@@ -30,7 +30,7 @@ const defekt = function <TErrorDefinition extends Record<string, { code?: string
         cause,
         data
       }: {
-        cause?: Error;
+        cause?: unknown;
         data?: any;
       } = {}) {
         /* eslint-enable default-param-last */


### PR DESCRIPTION
BREAKING CHANGE: So far, `cause` was of type `Error`, now it is of type `unknown`, which better represents the behavior of JavaScript and TypeScript.