### PR TITLE
fix: IsCustomError now works as intended; IsError is now simpler.

### DIFF
--- a/lib/CustomError.ts
+++ b/lib/CustomError.ts
@@ -1,10 +1,24 @@
-interface CustomError<TErrorName extends string = string> extends Error {
-  code: TErrorName;
-  message: string;
-  cause?: unknown;
-  data?: any;
+class CustomError<TErrorName extends string = string> extends Error {
+  public code: TErrorName;
+
+  public cause?: unknown;
+
+  public data?: any;
+
+  public constructor ({ code, message, cause, data }: {
+    code: TErrorName;
+    message: string;
+    cause?: unknown;
+    data?: any;
+  }) {
+    super(message);
+
+    this.code = code;
+    this.cause = cause;
+    this.data = data;
+  }
 }
 
-export type {
+export {
   CustomError
 };

--- a/lib/defekt.ts
+++ b/lib/defekt.ts
@@ -9,14 +9,8 @@ const defekt = function <TErrorCode extends string>({
   code: TErrorCode;
   defaultMessage?: string;
 }): ErrorConstructor<TErrorCode> {
-  return class extends Error implements CustomError<TErrorCode> {
+  return class extends CustomError<TErrorCode> {
     public static code: TErrorCode = code;
-
-    public code: TErrorCode = code;
-
-    public cause?: unknown;
-
-    public data?: any;
 
     public constructor (
       messageOrMetadata: string | {
@@ -25,16 +19,14 @@ const defekt = function <TErrorCode extends string>({
         message?: string;
       } = {}
     ) {
-      super(
-        typeof messageOrMetadata === 'string' ?
+      super({
+        code,
+        message: typeof messageOrMetadata === 'string' ?
           messageOrMetadata :
-          messageOrMetadata.message ?? defaultMessage ?? `${formatErrorMessage({ code })}`
-      );
-
-      if (typeof messageOrMetadata !== 'string') {
-        this.cause = messageOrMetadata.cause;
-        this.data = messageOrMetadata.data;
-      }
+          messageOrMetadata.message ?? defaultMessage ?? `${formatErrorMessage({ code })}`,
+        cause: typeof messageOrMetadata === 'string' ? undefined : messageOrMetadata.cause,
+        data: typeof messageOrMetadata === 'string' ? undefined : messageOrMetadata.data
+      });
     }
   };
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,10 +10,13 @@ export {
   CustomError,
   defekt,
   error,
-  ErrorConstructor,
   isCustomError,
   isError,
   isResult,
-  Result,
   value
+};
+
+export type {
+  ErrorConstructor,
+  Result
 };

--- a/lib/isCustomError.ts
+++ b/lib/isCustomError.ts
@@ -8,6 +8,7 @@ const isCustomError = function <TErrorName extends string>(
 ): ex is CustomError<TErrorName> {
   return (
     isError(ex) &&
+      ex instanceof CustomError &&
       (errorType === undefined || ((ex as any).code === errorType.code))
   );
 };

--- a/lib/isError.ts
+++ b/lib/isError.ts
@@ -1,9 +1,5 @@
 const isError = function (ex: any): ex is Error {
-  return (
-    typeof ex === 'object' && ex !== null &&
-    'message' in ex && typeof ex.message === 'string' &&
-    'name' in ex && typeof ex.name === 'string'
-  );
+  return typeof ex === 'object' && ex instanceof Error;
 };
 
 export { isError };

--- a/test/unit/isCustomErrorTests.ts
+++ b/test/unit/isCustomErrorTests.ts
@@ -47,6 +47,14 @@ suite('isCustomError', (): void => {
     assert.that(result).is.false();
   });
 
+  test('returns false, if the parameter is just a basic Error.', async (): Promise<void> => {
+    const ex = new Error('Foo.');
+
+    const result = isCustomError(ex);
+
+    assert.that(result).is.false();
+  });
+
   test('works with unknown type binding in catch clause.', async (): Promise<void> => {
     class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
 


### PR DESCRIPTION
I noticed in the wolkenkit that `isCustomError` would think that basic `Error`s were `CustomError`s and realized that the implementation did not check enough properties to avoid false positives.

I had two approaches in mind to make `isCustomError` precise:

1. As we did in earlier versions of `defekt`, check whether all expected properties exist and have the correct types. Basically manual type-checking. This works and keeps compatibility with other libraries that want to build error objects that are structurally compatible with our `CustomError`s, but it is rather complicated and error-prone.
2. Convert our `CustomError` interface to a class that inherits from `Error` and use it as the base class for any further custom errors. This allows us to check for `ex instanceof CustomError` in `isCustomError`. This is I think the slightly less elegant solution, since it relies on the prototype-chain, which is one of my least favorite features of JS. But in this case I think it works, since the assumption of `defekt` is that any project will use only `defekt` to create its custom errors and will only use `isCustomError` to recognize them. In that case structural type-checking and compatibility are not relevant and any error comparison logic goes through `defekt` anyway. Also, `isCustomError` is *much* simpler and less error-prone this way.

So this PR goes with option #2.

This PR also rewrites `isError` using the same approach - checking wether something is an object and then relying on `instanceof Error`. This fulfills all of our tests and has less surface for bugs.