### PR TITLE
fix: Remove type information discarding.

### DIFF
--- a/lib/Result.ts
+++ b/lib/Result.ts
@@ -1,17 +1,17 @@
 interface ResultBase<TValue, TError extends Error> {
-  hasError: () => this is ResultError<TError> & ResultBase<any, TError>;
-  hasValue: () => this is ResultValue<TValue> & ResultBase<TValue, any>;
+  hasError: () => this is ResultError<TValue, TError>;
+  hasValue: () => this is ResultValue<TValue, TError>;
 
   unwrapOrThrow: (errorTransformer?: (err: TError) => Error) => TValue;
   unwrapOrElse: (handleError: (error: Error) => TValue) => TValue;
   unwrapOrDefault: (defaultValue: TValue) => TValue;
 }
 
-interface ResultError<TError extends Error> {
+interface ResultError<TValue, TError extends Error> extends ResultBase<TValue, TError> {
   error: TError;
 }
 
-const error = function <TError extends Error>(err: TError): ResultError<TError> & ResultBase<any, TError> {
+const error = function <TValue, TError extends Error>(err: TError): ResultError<TValue, TError> {
   return {
     hasError (): boolean {
       return true;
@@ -26,24 +26,24 @@ const error = function <TError extends Error>(err: TError): ResultError<TError> 
       // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw err;
     },
-    unwrapOrElse<TValue> (handleError: (error: TError) => TValue): TValue {
+    unwrapOrElse (handleError: (error: TError) => TValue): TValue {
       return handleError(err);
     },
-    unwrapOrDefault<TValue> (defaultValue: TValue): TValue {
+    unwrapOrDefault (defaultValue: TValue): TValue {
       return defaultValue;
     },
     error: err
   };
 };
 
-interface ResultValue<TValue> {
+interface ResultValue<TValue, TError extends Error> extends ResultBase<TValue, TError> {
   value: TValue;
 }
 
 const value: {
-  <TValue extends undefined>(): ResultValue<TValue> & ResultBase<TValue, any>;
-  <TValue>(value: TValue): ResultValue<TValue> & ResultBase<TValue, any>;
-} = function <TValue>(val?: TValue): ResultValue<TValue | undefined> & ResultBase<TValue | undefined, any> {
+  <TValue extends undefined, TError extends Error>(): ResultValue<TValue, TError>;
+  <TValue, TError extends Error>(value: TValue): ResultValue<TValue, TError>;
+} = function <TValue, TError extends Error>(val?: TValue): ResultValue<TValue | undefined, TError> {
   return {
     hasError (): boolean {
       return false;
@@ -64,7 +64,7 @@ const value: {
   };
 };
 
-type Result<TValue, TError extends Error> = ResultBase<TValue, TError>;
+type Result<TValue, TError extends Error> = ResultValue<TValue, TError> | ResultError<TValue, TError>;
 
 export type {
   ResultValue,

--- a/test/unit/ResultTests.ts
+++ b/test/unit/ResultTests.ts
@@ -76,15 +76,6 @@ suite('Result', (): void => {
       assert.that(resultHasError).is.false();
     });
 
-    test(`narrows the type to the error case and discards value type information.`, async (): Promise<void> => {
-      const result = getValue();
-
-      if (result.hasError()) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const newResult: Result<{ something: 'elseEntirely' }, Error> = result;
-      }
-    });
-
     test('extrapolates value type correctly.', async (): Promise<void> => {
       const result = getValue();
 
@@ -112,19 +103,6 @@ suite('Result', (): void => {
       const resultHasValue = result.hasValue();
 
       assert.that(resultHasValue).is.false();
-    });
-
-    test(`narrows the type to the value case and discards error type information.`, async (): Promise<void> => {
-      const result = getValue();
-
-      interface CustomError extends Error {
-        bar: string;
-      }
-
-      if (result.hasValue()) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const newResult: Result<Value, CustomError> = result;
-      }
     });
 
     test('extrapolates error type correctly.', async (): Promise<void> => {
@@ -267,40 +245,5 @@ suite('Result', (): void => {
         }
       }
     });
-  });
-
-  test('is assignable to a result with the same error type if the result is known to be an error.', async (): Promise<void> => {
-    class CustomError extends Error {
-      public someProp = 0;
-    }
-
-    // This function compiling is enough for this test.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const someFunction = function (someResult: Result<number, CustomError>): Result<string, CustomError> {
-      if (someResult.hasError()) {
-        return someResult;
-      }
-
-      return error(new CustomError());
-    };
-  });
-
-  test('is assignable to a result with the same value type if the result is known to be an value.', async (): Promise<void> => {
-    class CustomError1 extends Error {
-      public someProp = 0;
-    }
-    class CustomError2 extends Error {
-      public someOtherProp = 'some string';
-    }
-
-    // This function compiling is enough for this test.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const someFunction = function (someResult: Result<string, CustomError1>): Result<string, CustomError2> {
-      if (someResult.hasValue()) {
-        return someResult;
-      }
-
-      return value('');
-    };
   });
 });

--- a/test/unit/ResultTests.ts
+++ b/test/unit/ResultTests.ts
@@ -84,6 +84,17 @@ suite('Result', (): void => {
         const newResult: Result<{ something: 'elseEntirely' }, Error> = result;
       }
     });
+
+    test('extrapolates value type correctly.', async (): Promise<void> => {
+      const result = getValue();
+
+      if (result.hasError()) {
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const containedValue: Value = result.value;
+    });
   });
 
   suite('hasValue', (): void => {
@@ -114,6 +125,17 @@ suite('Result', (): void => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const newResult: Result<Value, CustomError> = result;
       }
+    });
+
+    test('extrapolates error type correctly.', async (): Promise<void> => {
+      const result = getError();
+
+      if (result.hasValue()) {
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const containedError = result.error;
     });
   });
 
@@ -252,7 +274,7 @@ suite('Result', (): void => {
       public someProp = 0;
     }
 
-    // This function compiling it enough for this test.
+    // This function compiling is enough for this test.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const someFunction = function (someResult: Result<number, CustomError>): Result<string, CustomError> {
       if (someResult.hasError()) {
@@ -271,7 +293,7 @@ suite('Result', (): void => {
       public someOtherProp = 'some string';
     }
 
-    // This function compiling it enough for this test.
+    // This function compiling is enough for this test.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const someFunction = function (someResult: Result<string, CustomError1>): Result<string, CustomError2> {
       if (someResult.hasValue()) {


### PR DESCRIPTION
This PR:

- adds tests regarding our assumptions for type narrowing. If i do `if (result.hasError()) {}` I expect `result` to contain a value _after_ the `if` branch (assuming the if branch returns the function). This was not the case in the previous version but always assumed behavior
- removes the type information discarding feature from ~2 versions ago, where checking if something contains an error would discard type information about the value case for more convenient early returns. this lead to probably unfixable type collisions. I would love to fix them without removing the feature, but currently it doesn't seem feasible
