### PR TITLE
feat: Hydrate CustomError and Result.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ try {
 const error = new TokenMalformed({ data: { foo: 'bar' }});
 ```
 
-#### Hydrating errors
+#### Serializing and Hydrating errors
 
 Sometimes you need to serialize and deserialize your errors. Afterwards they are missing their prototype-chain and `Error`-related functionality. To restore those, you can hydrate a raw object to a `CustomError`-instance:
 
@@ -126,12 +126,16 @@ import { defekt, hydrateCustomError } from 'defekt';
 
 class TokenMalformed extends defekt({ code: 'TokenMalformed' }) {}
 
-const rawEx = JSON.parse(tokenMalformedErrorFromSomewhere);
+const serializedTokenMalformedError = JSON.stringify(new TokenMalformed());
+
+const rawEx = JSON.parse(serializedTokenMalformedError);
 
 const ex = hydrateCustomError({ rawEx, potentialErrorConstructors: [ TokenMalformed ] }).unwrapOrThrow();
 ```
 
 Note that the hydrated error is wrapped in a `Result`. If the raw error can not be hydrated using one of the given potential error constructors, an error-`Result` will be returned, which tells you, why the hydration was unsuccessful.
+
+Usually, JavaScript `Error`s are not well suited for JSON-serialization. To improve this, the `CustomError` class implements [`toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior), which defines custom JSON-serialization behavior. If you want to be able to serialize your `cause` and `data` as well, they need to be either plain objects or also implement the `toJSON` method.
 
 ### Using custom error type-guards
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ if (hydrationResult.hasError()) {
 }
 ```
 
+You can also optionally let `hydrateResult` hydrate the contained error by passing `potentialErrorConstructors`. This works identically to `hydrateResult`.
+
 ## Running quality assurance
 
 To run quality assurance for this module use [roboter](https://www.npmjs.com/package/roboter):

--- a/README.md
+++ b/README.md
@@ -302,6 +302,22 @@ if (isResult(someValue)) {
 }
 ```
 
+### Hydrating a `Result`
+
+Like for errors, there is a function to hydrate a `Result` from raw data in case you need to serialize and deserialize a `Result`. Be careful with this, however: The hydration function is designed to accept everything as a valid result and treat its input as a `Result<undefined, any>` if it cannot find either a value or an error. So make sure that you are confident that the value you hydrate is actually something that makes sense as a `Result`.
+
+```typescript
+import { defekt, hydrateResult } from 'defekt';
+
+const rawResult = JSON.parse(resultFromSomewhere);
+
+const result = hydrateResult({ rawResult });
+
+if (result.hasError()) {
+    // Continue with your normal error handling. Just note that you might have to hydrate the contained error as well.
+}
+```
+
 ## Running quality assurance
 
 To run quality assurance for this module use [roboter](https://www.npmjs.com/package/roboter):

--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ try {
 const error = new TokenMalformed({ data: { foo: 'bar' }});
 ```
 
+#### Hydrating errors
+
+Sometimes you need to serialize and deserialize your errors. Afterwards they are missing their prototype-chain and Error-related functionality. To restore those, you can hydrate a raw object to a `CustomError`-instance:
+
+```typescript
+import { defekt, hydrateCustomError } from 'defekt';
+
+class TokenMalformed extends defekt({ code: 'TokenMalformed' }) {}
+
+const rawEx = JSON.parse(tokenMalformedErrorFromSomewhere);
+
+const ex = hydrateCustomError({rawEx, potentialErrorConstructors: [ TokenMalformed ]}).unwrapOrThrow();
+```
+
+If the raw error can not be hydrated using one of the given potential error constructors, an error will be returned.
+
 ### Using custom error type-guards
 
 Custom errors can be type-guarded using `isCustomError`. With only one parameter it specifies an error's type to `CustomError`:

--- a/README.md
+++ b/README.md
@@ -309,17 +309,23 @@ if (isResult(someValue)) {
 
 ### Hydrating a `Result`
 
-Like for errors, there is a function to hydrate a `Result` from raw data in case you need to serialize and deserialize a `Result`. Be careful with this, however: The hydration function is designed to accept everything as a valid result and treat its input as a `Result<undefined, any>` if it cannot find either a value or an error. So make sure that you are confident that the value you hydrate is actually something that makes sense as a `Result`:
+Like for errors, there is a function to hydrate a `Result` from raw data in case you need to serialize and deserialize a `Result`.
 
 ```typescript
 import { defekt, hydrateResult } from 'defekt';
 
 const rawResult = JSON.parse(resultFromSomewhere);
 
-const result = hydrateResult({ rawResult });
+const hydrationResult = hydrateResult({ rawResult });
 
-if (result.hasError()) {
-    // Continue with your normal error handling. Just note that you might have to hydrate the contained error as well.
+if (hydrationResult.hasError()) {
+    // The hydration has failed.
+} else {
+    const result = hydrationResult.value;
+    
+    if (result.hasError()) {
+        // Continue with your normal error handling.
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const error = new TokenMalformed({ data: { foo: 'bar' }});
 
 #### Hydrating errors
 
-Sometimes you need to serialize and deserialize your errors. Afterwards they are missing their prototype-chain and Error-related functionality. To restore those, you can hydrate a raw object to a `CustomError`-instance:
+Sometimes you need to serialize and deserialize your errors. Afterwards they are missing their prototype-chain and `Error`-related functionality. To restore those, you can hydrate a raw object to a `CustomError`-instance:
 
 ```typescript
 import { defekt, hydrateCustomError } from 'defekt';
@@ -128,10 +128,10 @@ class TokenMalformed extends defekt({ code: 'TokenMalformed' }) {}
 
 const rawEx = JSON.parse(tokenMalformedErrorFromSomewhere);
 
-const ex = hydrateCustomError({rawEx, potentialErrorConstructors: [ TokenMalformed ]}).unwrapOrThrow();
+const ex = hydrateCustomError({ rawEx, potentialErrorConstructors: [ TokenMalformed ] }).unwrapOrThrow();
 ```
 
-If the raw error can not be hydrated using one of the given potential error constructors, an error will be returned.
+Note that the hydrated error is wrapped in a `Result`. If the raw error can not be hydrated using one of the given potential error constructors, an error-`Result` will be returned, which tells you, why the hydration was unsuccessful.
 
 ### Using custom error type-guards
 
@@ -304,7 +304,7 @@ if (isResult(someValue)) {
 
 ### Hydrating a `Result`
 
-Like for errors, there is a function to hydrate a `Result` from raw data in case you need to serialize and deserialize a `Result`. Be careful with this, however: The hydration function is designed to accept everything as a valid result and treat its input as a `Result<undefined, any>` if it cannot find either a value or an error. So make sure that you are confident that the value you hydrate is actually something that makes sense as a `Result`.
+Like for errors, there is a function to hydrate a `Result` from raw data in case you need to serialize and deserialize a `Result`. Be careful with this, however: The hydration function is designed to accept everything as a valid result and treat its input as a `Result<undefined, any>` if it cannot find either a value or an error. So make sure that you are confident that the value you hydrate is actually something that makes sense as a `Result`:
 
 ```typescript
 import { defekt, hydrateResult } from 'defekt';

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ try {
 const error = new TokenMalformed({ data: { foo: 'bar' }});
 ```
 
-#### Serializing and Hydrating errors
+#### Serializing, Deserializing and Hydrating errors
 
 Sometimes you need to serialize and deserialize your errors. Afterwards they are missing their prototype-chain and `Error`-related functionality. To restore those, you can hydrate a raw object to a `CustomError`-instance:
 
@@ -134,6 +134,7 @@ const ex = hydrateCustomError({ rawEx, potentialErrorConstructors: [ TokenMalfor
 ```
 
 Note that the hydrated error is wrapped in a `Result`. If the raw error can not be hydrated using one of the given potential error constructors, an error-`Result` will be returned, which tells you, why the hydration was unsuccessful.
+Also note that the `cause` of a `CustomError` is currently not hydrated, but left as-is.
 
 Usually, JavaScript `Error`s are not well suited for JSON-serialization. To improve this, the `CustomError` class implements [`toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior), which defines custom JSON-serialization behavior. If you want to be able to serialize your `cause` and `data` as well, they need to be either plain objects or also implement the `toJSON` method.
 

--- a/lib/CustomError.ts
+++ b/lib/CustomError.ts
@@ -20,14 +20,27 @@ class CustomError<TErrorName extends string = string> extends Error {
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public toJSON (): any {
-    return {
+    const serializableObject: any = {
       name: this.name,
       message: this.message,
       code: this.code,
-      data: this.data,
-      cause: this.cause,
       stack: this.stack
     };
+
+    try {
+      JSON.stringify(this.data);
+      serializableObject.data = this.data;
+    } catch {
+      // If data is not serializable, we want to omit it from the returned object.
+    }
+    try {
+      JSON.stringify(this.cause);
+      serializableObject.cause = this.cause;
+    } catch {
+      // If data is not serializable, we want to omit it from the returned object.
+    }
+
+    return serializableObject;
   }
 }
 

--- a/lib/CustomError.ts
+++ b/lib/CustomError.ts
@@ -19,15 +19,15 @@ class CustomError<TErrorName extends string = string> extends Error {
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  public toJSON (): string {
-    return JSON.stringify({
+  public toJSON (): any {
+    return {
       name: this.name,
       message: this.message,
       code: this.code,
       data: this.data,
       cause: this.cause,
       stack: this.stack
-    });
+    };
   }
 }
 

--- a/lib/CustomError.ts
+++ b/lib/CustomError.ts
@@ -17,6 +17,18 @@ class CustomError<TErrorName extends string = string> extends Error {
     this.cause = cause;
     this.data = data;
   }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public toJSON (): string {
+    return JSON.stringify({
+      name: this.name,
+      message: this.message,
+      code: this.code,
+      data: this.data,
+      cause: this.cause,
+      stack: this.stack
+    });
+  }
 }
 
 export {

--- a/lib/hydrateCustomError.ts
+++ b/lib/hydrateCustomError.ts
@@ -5,12 +5,12 @@ import { error, Result, value } from './Result';
 
 class HydratingErrorFailed extends defekt({ code: 'HydratingErrorFailed' }) {}
 
-const hydrateCustomError = function ({
+const hydrateCustomError = function<TPotentialCustomErrorNames extends string = string> ({
   rawEx, potentialErrorConstructors
 }: {
   rawEx: any;
-  potentialErrorConstructors: CustomErrorConstructor<any>[];
-}): Result<CustomError, HydratingErrorFailed> {
+  potentialErrorConstructors: CustomErrorConstructor<TPotentialCustomErrorNames>[];
+}): Result<CustomError<TPotentialCustomErrorNames>, HydratingErrorFailed> {
   if (typeof rawEx !== 'object' || rawEx === null) {
     return error(new HydratingErrorFailed('The given error is not an object.'));
   }

--- a/lib/hydrateCustomError.ts
+++ b/lib/hydrateCustomError.ts
@@ -38,17 +38,7 @@ const hydrateCustomError = function<TPotentialCustomErrorNames extends string = 
 
   const stack = rawEx?.stack;
   const data = rawEx?.data;
-  let cause: undefined | Error;
-
-  if ('cause' in rawEx && rawEx.cause !== undefined) {
-    const causeResult = hydrateCustomError({ rawEx: rawEx.cause, potentialErrorConstructors });
-
-    if (causeResult.hasError()) {
-      return error(new HydratingErrorFailed({ message: 'The given error has a cause that could not be hydrated.', cause: causeResult.error }));
-    }
-
-    cause = causeResult.value;
-  }
+  const cause = rawEx?.cause;
 
   const hydratedError = new ActualErrorConstructor({ message: rawEx.message, cause, data });
 

--- a/lib/hydrateCustomError.ts
+++ b/lib/hydrateCustomError.ts
@@ -1,0 +1,65 @@
+import { CustomError } from './CustomError';
+import { CustomErrorConstructor } from './CustomErrorConstructor';
+import { defekt } from './defekt';
+import { error, Result, value } from './Result';
+
+class HydratingErrorFailed extends defekt({ code: 'HydratingErrorFailed' }) {}
+
+const hydrateCustomError = function ({
+  rawEx, potentialErrorConstructors
+}: {
+  rawEx: any;
+  potentialErrorConstructors: CustomErrorConstructor<any>[];
+}): Result<CustomError, HydratingErrorFailed> {
+  if (typeof rawEx !== 'object' || rawEx === null) {
+    return error(new HydratingErrorFailed('The given error is not an object.'));
+  }
+
+  if (!('name' in rawEx)) {
+    return error(new HydratingErrorFailed('The given error is missing a name.'));
+  }
+  if (!('code' in rawEx)) {
+    return error(new HydratingErrorFailed('The given error is missing a code.'));
+  }
+  if (!('message' in rawEx)) {
+    return error(new HydratingErrorFailed('The given error is missing a message.'));
+  }
+
+  const ActualErrorConstructor = potentialErrorConstructors.find(
+    (errorContructor): boolean => errorContructor.code === rawEx.code
+  );
+
+  if (ActualErrorConstructor === undefined) {
+    return error(new HydratingErrorFailed({
+      message: 'Could not find an appropriate ErrorConstructor to hydrate the given error.',
+      data: { code: rawEx.code }
+    }));
+  }
+
+  const stack = rawEx?.stack;
+  const data = rawEx?.data;
+  let cause: undefined | Error;
+
+  if ('cause' in rawEx && rawEx.cause !== undefined) {
+    const causeResult = hydrateCustomError({ rawEx: rawEx.cause, potentialErrorConstructors });
+
+    if (causeResult.hasError()) {
+      return error(new HydratingErrorFailed({ message: 'The given error has a cause that could not be hydrated.', cause: causeResult.error }));
+    }
+
+    cause = causeResult.value;
+  }
+
+  const hydratedError = new ActualErrorConstructor({ message: rawEx.message, cause, data });
+
+  hydratedError.name = rawEx.name;
+  hydratedError.stack = stack;
+
+  return value(hydratedError);
+};
+
+export {
+  HydratingErrorFailed,
+
+  hydrateCustomError
+};

--- a/lib/hydrateResult.ts
+++ b/lib/hydrateResult.ts
@@ -1,16 +1,19 @@
+import { defekt } from './defekt';
 import { error, Result, value } from './Result';
 
-const hydrateResult = function ({ rawResult }: {
-  rawResult: { value?: any } | { error: any };
-}): Result<any, any> {
+class HydratingResultFailed extends defekt({ code: 'HydratingResultFailed' }) {}
+
+const hydrateResult = function<TValue, TError extends Error> ({ rawResult }: {
+  rawResult: { value: TValue } | { error: TError };
+}): Result<Result<TValue, TError>, HydratingResultFailed> {
   if ('value' in rawResult) {
-    return value(rawResult.value);
+    return value(value(rawResult.value) as Result<TValue, TError>);
   }
   if ('error' in rawResult) {
-    return error(rawResult.error);
+    return value(error(rawResult.error) as Result<TValue, TError>);
   }
 
-  return value();
+  return error(new HydratingResultFailed());
 };
 
 export {

--- a/lib/hydrateResult.ts
+++ b/lib/hydrateResult.ts
@@ -1,16 +1,32 @@
+import { CustomError } from './CustomError';
+import { CustomErrorConstructor } from './CustomErrorConstructor';
 import { defekt } from './defekt';
+import { hydrateCustomError } from './hydrateCustomError';
 import { error, Result, value } from './Result';
 
 class HydratingResultFailed extends defekt({ code: 'HydratingResultFailed' }) {}
 
-const hydrateResult = function<TValue, TError extends Error> ({ rawResult }: {
+const hydrateResult = function<TValue, TError extends Error, TPotentialCustomErrorNames extends string = string> ({ rawResult, potentialErrorConstructors }: {
   rawResult: { value: TValue } | { error: TError };
-}): Result<Result<TValue, TError>, HydratingResultFailed> {
+  potentialErrorConstructors?: CustomErrorConstructor<TPotentialCustomErrorNames>[];
+}): Result<Result<TValue, TError | CustomError<TPotentialCustomErrorNames>>, HydratingResultFailed> {
   if ('value' in rawResult) {
-    return value(value(rawResult.value) as Result<TValue, TError>);
+    return value(value(rawResult.value) as Result<TValue, any>);
   }
   if ('error' in rawResult) {
-    return value(error(rawResult.error) as Result<TValue, TError>);
+    let processedError: Error = rawResult.error;
+
+    if (potentialErrorConstructors) {
+      const hydrateErrorResult = hydrateCustomError({ rawEx: rawResult.error, potentialErrorConstructors });
+
+      if (hydrateErrorResult.hasError()) {
+        return error(new HydratingResultFailed({ cause: hydrateErrorResult.error }));
+      }
+
+      processedError = hydrateErrorResult.value;
+    }
+
+    return value(error(processedError) as Result<TValue, any>);
   }
 
   return error(new HydratingResultFailed());

--- a/lib/hydrateResult.ts
+++ b/lib/hydrateResult.ts
@@ -1,0 +1,18 @@
+import { error, Result, value } from './Result';
+
+const hydrateResult = function ({ rawResult }: {
+  rawResult: { value?: any } | { error: any };
+}): Result<any, any> {
+  if ('value' in rawResult) {
+    return value(rawResult.value);
+  }
+  if ('error' in rawResult) {
+    return error(rawResult.error);
+  }
+
+  return value();
+};
+
+export {
+  hydrateResult
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,11 +5,14 @@ import { isCustomError } from './isCustomError';
 import { isError } from './isError';
 import { isResult } from './isResult';
 import { error, Result, value } from './Result';
+import { hydrateCustomError, HydratingErrorFailed } from './hydrateCustomError';
 
 export {
   CustomError,
   defekt,
   error,
+  hydrateCustomError,
+  HydratingErrorFailed,
   isCustomError,
   isError,
   isResult,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import { CustomError } from './CustomError';
 import { CustomErrorConstructor } from './CustomErrorConstructor';
 import { defekt } from './defekt';
+import { hydrateResult } from './hydrateResult';
 import { isCustomError } from './isCustomError';
 import { isError } from './isError';
 import { isResult } from './isResult';
@@ -13,6 +14,7 @@ export {
   error,
   hydrateCustomError,
   HydratingErrorFailed,
+  hydrateResult,
   isCustomError,
   isError,
   isResult,

--- a/test/unit/defektTests.ts
+++ b/test/unit/defektTests.ts
@@ -121,4 +121,20 @@ suite('defekt', (): void => {
       }
     }
   });
+
+  test('creates a custom error that serializes to JSON in a meaningful way.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+
+    const cause = new TokenInvalid();
+    const ex = new TokenInvalid({ message: 'Foo', data: { foo: 'bar' }, cause });
+
+    assert.that(JSON.stringify(ex)).is.equalTo(JSON.stringify({
+      name: 'TokenInvalid',
+      message: formatErrorMessage({ code: 'TokenInvalid' }),
+      code: 'TokenInvalid',
+      stack: ex.stack,
+      data: { foo: 'bar' },
+      cause: JSON.stringify(cause)
+    }));
+  });
 });

--- a/test/unit/defektTests.ts
+++ b/test/unit/defektTests.ts
@@ -137,4 +137,38 @@ suite('defekt', (): void => {
       cause: JSON.stringify(cause)
     }));
   });
+
+  test('creates a custom error that serializes to JSON and omits cause if it is not serializable.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+
+    const objectA: any = {};
+    const objectB: any = { objectA };
+
+    objectA.objectB = objectB;
+    const ex = new TokenInvalid({ message: 'Foo', cause: objectA });
+
+    assert.that(JSON.stringify(ex)).is.equalTo(JSON.stringify({
+      name: 'TokenInvalid',
+      message: formatErrorMessage({ code: 'TokenInvalid' }),
+      code: 'TokenInvalid',
+      stack: ex.stack
+    }));
+  });
+
+  test('creates a custom error that serializes to JSON and omits data if it is not serializable.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+
+    const objectA: any = {};
+    const objectB: any = { objectA };
+
+    objectA.objectB = objectB;
+    const ex = new TokenInvalid({ message: 'Foo', data: objectA });
+
+    assert.that(JSON.stringify(ex)).is.equalTo(JSON.stringify({
+      name: 'TokenInvalid',
+      message: formatErrorMessage({ code: 'TokenInvalid' }),
+      code: 'TokenInvalid',
+      stack: ex.stack
+    }));
+  });
 });

--- a/test/unit/hydrateCustomErrorTests.ts
+++ b/test/unit/hydrateCustomErrorTests.ts
@@ -1,0 +1,106 @@
+import { assert } from 'assertthat';
+import { defekt, hydrateCustomError, isCustomError } from '../../lib';
+
+suite('hydrateCustomError', (): void => {
+  test('creates an error instance from raw data.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+    class TokenExpired extends defekt({ code: 'TokenExpired' }) {}
+
+    const rawEx = {
+      name: 'TokenInvalid',
+      code: 'TokenInvalid',
+      message: 'Foo',
+      data: { foo: 'bar' },
+      cause: {
+        name: 'TokenExpired',
+        code: 'TokenExpired',
+        message: 'Token expired.'
+      }
+    };
+
+    const ex = hydrateCustomError({
+      rawEx,
+      potentialErrorConstructors: [ TokenInvalid, TokenExpired ]
+    }).unwrapOrThrow();
+
+    assert.that(isCustomError(ex, TokenInvalid)).is.true();
+    assert.that(isCustomError(ex.cause, TokenExpired)).is.true();
+  });
+
+  test('fails to hydrate an error that is missing a name.', async (): Promise<void> => {
+    const rawEx = {
+      code: 'TokenInvalid',
+      message: 'Foo'
+    };
+
+    const hydrateResult = hydrateCustomError({
+      rawEx,
+      potentialErrorConstructors: []
+    });
+
+    assert.that(hydrateResult).is.anErrorWithMessage('The given error is missing a name.');
+  });
+
+  test('fails to hydrate an error that is missing a code.', async (): Promise<void> => {
+    const rawEx = {
+      name: 'TokenInvalid',
+      message: 'Foo'
+    };
+
+    const hydrateResult = hydrateCustomError({
+      rawEx,
+      potentialErrorConstructors: []
+    });
+
+    assert.that(hydrateResult).is.anErrorWithMessage('The given error is missing a code.');
+  });
+
+  test('fails to hydrate an error that is missing a message.', async (): Promise<void> => {
+    const rawEx = {
+      name: 'TokenInvalid',
+      code: 'TokenInvalid'
+    };
+
+    const hydrateResult = hydrateCustomError({
+      rawEx,
+      potentialErrorConstructors: []
+    });
+
+    assert.that(hydrateResult).is.anErrorWithMessage('The given error is missing a message.');
+  });
+
+  test('fails to hydrate an error for which no appropriate error constructer is given.', async (): Promise<void> => {
+    class TokenExpired extends defekt({ code: 'TokenExpired' }) {}
+
+    const rawEx = {
+      name: 'TokenInvalid',
+      code: 'TokenInvalid',
+      message: 'Foo'
+    };
+
+    const hydrateResult = hydrateCustomError({
+      rawEx,
+      potentialErrorConstructors: [ TokenExpired ]
+    });
+
+    assert.that(hydrateResult).is.anErrorWithMessage('Could not find an appropriate ErrorConstructor to hydrate the given error.');
+  });
+
+  test('fails to hydrate an error if its cause can not be hydrated.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+
+    const rawEx = {
+      name: 'TokenInvalid',
+      code: 'TokenInvalid',
+      message: 'Foo',
+      cause: {}
+    };
+
+    const hydrateResult = hydrateCustomError({
+      rawEx,
+      potentialErrorConstructors: [ TokenInvalid ]
+    });
+
+    assert.that(hydrateResult).is.anErrorWithMessage('The given error has a cause that could not be hydrated.');
+  });
+});

--- a/test/unit/hydrateCustomErrorTests.ts
+++ b/test/unit/hydrateCustomErrorTests.ts
@@ -24,7 +24,7 @@ suite('hydrateCustomError', (): void => {
     }).unwrapOrThrow();
 
     assert.that(isCustomError(ex, TokenInvalid)).is.true();
-    assert.that(isCustomError(ex.cause, TokenExpired)).is.true();
+    assert.that(ex.cause).is.equalTo(rawEx.cause);
   });
 
   test('fails to hydrate an error that is missing a name.', async (): Promise<void> => {
@@ -84,24 +84,6 @@ suite('hydrateCustomError', (): void => {
     });
 
     assert.that(hydrateResult).is.anErrorWithMessage('Could not find an appropriate ErrorConstructor to hydrate the given error.');
-  });
-
-  test('fails to hydrate an error if its cause can not be hydrated.', async (): Promise<void> => {
-    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
-
-    const rawEx = {
-      name: 'TokenInvalid',
-      code: 'TokenInvalid',
-      message: 'Foo',
-      cause: {}
-    };
-
-    const hydrateResult = hydrateCustomError({
-      rawEx,
-      potentialErrorConstructors: [ TokenInvalid ]
-    });
-
-    assert.that(hydrateResult).is.anErrorWithMessage('The given error has a cause that could not be hydrated.');
   });
 
   test('can hydrate serialized and deserialized errors.', async (): Promise<void> => {

--- a/test/unit/hydrateCustomErrorTests.ts
+++ b/test/unit/hydrateCustomErrorTests.ts
@@ -103,4 +103,16 @@ suite('hydrateCustomError', (): void => {
 
     assert.that(hydrateResult).is.anErrorWithMessage('The given error has a cause that could not be hydrated.');
   });
+
+  test('can hydrate serialized and deserialized errors.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+
+    const ex = new TokenInvalid();
+    const hydratedEx = hydrateCustomError({
+      rawEx: JSON.parse(JSON.stringify(ex)),
+      potentialErrorConstructors: [ TokenInvalid ]
+    }).unwrapOrThrow();
+
+    assert.that(isCustomError(hydratedEx, TokenInvalid)).is.true();
+  });
 });

--- a/test/unit/hydrateResultTests.ts
+++ b/test/unit/hydrateResultTests.ts
@@ -1,0 +1,48 @@
+import { assert } from 'assertthat';
+import { error, hydrateResult, value } from '../../lib';
+
+suite('hydrateResult', (): void => {
+  test('creates a Result instance from raw data containing a value.', async (): Promise<void> => {
+    const rawResult = {
+      value: 'foo'
+    };
+
+    const result = hydrateResult({ rawResult });
+
+    assert.that(result).is.aValue();
+    assert.that(result).is.equalTo(value('foo'));
+  });
+
+  test('creates a Result instance from raw data containing an error.', async (): Promise<void> => {
+    const ex = new Error('Foo');
+    const rawResult = {
+      error: ex
+    };
+
+    const result = hydrateResult({ rawResult });
+
+    assert.that(result).is.anErrorWithMessage('Foo');
+    assert.that(result).is.equalTo(error(ex));
+  });
+
+  test('creates a Result instance from raw data containing neither a value nor an error.', async (): Promise<void> => {
+    const rawResult = {};
+
+    const result = hydrateResult({ rawResult });
+
+    assert.that(result).is.aValue();
+    assert.that(result).is.equalTo(value());
+  });
+
+  test('ignores any unknown properties in the raw data.', async (): Promise<void> => {
+    const rawResult = {
+      foo: 'bar',
+      bam: 'baz'
+    } as any;
+
+    const result = hydrateResult({ rawResult });
+
+    assert.that(result).is.aValue();
+    assert.that(result).is.equalTo(value());
+  });
+});

--- a/test/unit/hydrateResultTests.ts
+++ b/test/unit/hydrateResultTests.ts
@@ -1,5 +1,5 @@
 import { assert } from 'assertthat';
-import { error, hydrateResult, Result, value } from '../../lib';
+import { CustomError, defekt, error, hydrateResult, Result, value } from '../../lib';
 
 suite('hydrateResult', (): void => {
   test('creates a Result instance from raw data containing a value.', async (): Promise<void> => {
@@ -33,5 +33,46 @@ suite('hydrateResult', (): void => {
     const result = hydrateResult({ rawResult } as any);
 
     assert.that(result).is.anErrorWithMessage('Hydrating result failed.');
+  });
+
+  test('hydrates the contained error if given potential error constructors.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+
+    const rawResult = {
+      error: {
+        name: 'TokenInvalid',
+        code: 'TokenInvalid',
+        message: 'Foo'
+      }
+    };
+
+    const hydrateResultResult = hydrateResult({
+      rawResult,
+      potentialErrorConstructors: [ TokenInvalid ]
+    });
+
+    assert.that(hydrateResultResult).is.aValue();
+    assert.that(hydrateResultResult.unwrapOrThrow()).is.anErrorWithMessage('Foo');
+    assert.that(hydrateResultResult.unwrapOrThrow().unwrapErrorOrThrow().code).is.equalTo('TokenInvalid');
+  });
+
+  test('returns an error if the contained error is not hydratable with any of the given potential error constructors.', async (): Promise<void> => {
+    class TokenExpired extends defekt({ code: 'TokenExpired' }) {}
+
+    const rawResult = {
+      error: {
+        name: 'TokenInvalid',
+        code: 'TokenInvalid',
+        message: 'Foo'
+      }
+    };
+
+    const hydrateResultResult = hydrateResult({
+      rawResult,
+      potentialErrorConstructors: [ TokenExpired ]
+    });
+
+    assert.that(hydrateResultResult).is.anErrorWithMessage('Hydrating result failed.');
+    assert.that((hydrateResultResult.unwrapErrorOrThrow().cause as CustomError).code).is.equalTo('HydratingErrorFailed');
   });
 });


### PR DESCRIPTION
RFC @dotKuro @goloroden @strangedev 

As discussed with @strangedev via slack, I needed a way to hydrate Errors and Results that were JSON-serialized before. That means multiple things:

- custom JSON serialization for Errors, since native Errors have the worst JSON serialization (namely none)
- hydration of Results from basically arbitrary data, since a `Result<undefined, ...>` is represented in JSON as an empty object

Please take a look at the implementations and the documentation and reasoning for them and leave some feedback on wether you think this solution makes sense. Until I get some feedback I'll leave this as a draft.