### PR TITLE
feat: Allow type-definition of CustomError.data

### DIFF
--- a/lib/CustomError.ts
+++ b/lib/CustomError.ts
@@ -1,13 +1,13 @@
-class CustomError<TErrorName extends string = string> extends Error {
-  public code: TErrorName;
+class CustomError<TDataType = any, TErrorCode extends string = string> extends Error {
+  public code: TErrorCode;
 
-  public data?: any;
+  public data?: TDataType;
 
   public constructor ({ code, message, cause, data }: {
-    code: TErrorName;
+    code: TErrorCode;
     message: string;
     cause?: Error;
-    data?: any;
+    data?: TDataType;
   }) {
     super(message);
 

--- a/lib/CustomError.ts
+++ b/lib/CustomError.ts
@@ -1,13 +1,13 @@
-class CustomError<TDataType = any, TErrorCode extends string = string> extends Error {
+class CustomError<TData = any, TErrorCode extends string = string> extends Error {
   public code: TErrorCode;
 
-  public data?: TDataType;
+  public data?: TData;
 
   public constructor ({ code, message, cause, data }: {
     code: TErrorCode;
     message: string;
     cause?: Error;
-    data?: TDataType;
+    data?: TData;
   }) {
     super(message);
 

--- a/lib/CustomErrorConstructor.ts
+++ b/lib/CustomErrorConstructor.ts
@@ -1,9 +1,9 @@
 import { CustomError } from './CustomError';
 
-interface CustomErrorConstructor<TDataType = any, TErrorCode extends string = string> {
+interface CustomErrorConstructor<TData = any, TErrorCode extends string = string> {
   new(
-    parameters?: string | { cause?: Error; data?: TDataType; message?: string }
-  ): CustomError<TDataType, TErrorCode>;
+    parameters?: string | { cause?: Error; data?: TData; message?: string }
+  ): CustomError<TData, TErrorCode>;
 
   code: string;
 }

--- a/lib/CustomErrorConstructor.ts
+++ b/lib/CustomErrorConstructor.ts
@@ -1,9 +1,9 @@
 import { CustomError } from './CustomError';
 
-interface CustomErrorConstructor<TErrorName extends string> {
+interface CustomErrorConstructor<TDataType = any, TErrorCode extends string = string> {
   new(
-    parameters?: string | { cause?: Error; data?: any; message?: string }
-  ): CustomError<TErrorName>;
+    parameters?: string | { cause?: Error; data?: TDataType; message?: string }
+  ): CustomError<TDataType, TErrorCode>;
 
   code: string;
 }

--- a/lib/defekt.ts
+++ b/lib/defekt.ts
@@ -2,20 +2,20 @@ import { CustomError } from './CustomError';
 import { CustomErrorConstructor } from './CustomErrorConstructor';
 import { formatErrorMessage } from './formatErrorMessage';
 
-const defekt = function <TErrorCode extends string>({
+const defekt = function <TDataType = any, TErrorCode extends string = string>({
   code,
   defaultMessage
 }: {
   code: TErrorCode;
   defaultMessage?: string;
-}): CustomErrorConstructor<TErrorCode> {
-  return class extends CustomError<TErrorCode> {
+}): CustomErrorConstructor<TDataType, TErrorCode> {
+  return class extends CustomError<TDataType, TErrorCode> {
     public static code: TErrorCode = code;
 
     public constructor (
       messageOrMetadata: string | {
         cause?: Error;
-        data?: any;
+        data?: TDataType;
         message?: string;
       } = {}
     ) {

--- a/lib/defekt.ts
+++ b/lib/defekt.ts
@@ -2,20 +2,20 @@ import { CustomError } from './CustomError';
 import { CustomErrorConstructor } from './CustomErrorConstructor';
 import { formatErrorMessage } from './formatErrorMessage';
 
-const defekt = function <TDataType = any, TErrorCode extends string = string>({
+const defekt = function <TData = any, TErrorCode extends string = string>({
   code,
   defaultMessage
 }: {
   code: TErrorCode;
   defaultMessage?: string;
-}): CustomErrorConstructor<TDataType, TErrorCode> {
-  return class extends CustomError<TDataType, TErrorCode> {
+}): CustomErrorConstructor<TData, TErrorCode> {
+  return class extends CustomError<TData, TErrorCode> {
     public static code: TErrorCode = code;
 
     public constructor (
       messageOrMetadata: string | {
         cause?: Error;
-        data?: TDataType;
+        data?: TData;
         message?: string;
       } = {}
     ) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     {
       "name": "Noah Hummel",
       "email": "noah.hummel@thenativeweb.io"
+    },
+    {
+      "name": "Niclas Roßberger",
+      "email": "niclas+defekt@nidomiro.de"
     }
   ],
   "private": false,

--- a/test/unit/defektTests.ts
+++ b/test/unit/defektTests.ts
@@ -171,4 +171,13 @@ suite('defekt', (): void => {
       stack: ex.stack
     }));
   });
+
+  test('creates a custom error that has typed data.', async (): Promise<void> => {
+    class MyCustomDefekt extends defekt<{ attrA: string; attrB: number }>({ code: 'MyCustomDefekt' }) {}
+
+    const ex = new MyCustomDefekt({ data: { attrA: 'data', attrB: 2 }});
+
+    assert.that(ex.data?.attrA).is.equalTo('data');
+    assert.that(ex.data?.attrB).is.equalTo(2);
+  });
 });


### PR DESCRIPTION
Allows typing of `CustomError.data` to store known additional Information in an predefined format.

The only caveat I can think of is with hydration.
There the type can be misleading due to Serialisation/Deserilisation with classes. But actual runtime-behaviour is the same as the current implementation.