### PR TITLE
fix: Infer type correctly from unknown

### DIFF
--- a/lib/isCustomError.ts
+++ b/lib/isCustomError.ts
@@ -2,10 +2,10 @@ import { CustomError } from './CustomError';
 import { CustomErrorConstructor } from './CustomErrorConstructor';
 import { isError } from './isError';
 
-const isCustomError = function <TErrorName extends string>(
+const isCustomError = function <TData, TErrorName extends string>(
   ex: any,
-  errorType?: CustomErrorConstructor<TErrorName>
-): ex is CustomError<TErrorName> {
+  errorType?: CustomErrorConstructor<TData, TErrorName>
+): ex is CustomError<TData, TErrorName> {
   return (
     isError(ex) &&
       ex instanceof CustomError &&

--- a/test/unit/isCustomErrorTests.ts
+++ b/test/unit/isCustomErrorTests.ts
@@ -95,4 +95,44 @@ suite('isCustomError', (): void => {
       assertIsCustomError(ex);
     }
   });
+
+  test('acts as a type guard for specific custom errors starting from an error with type unknown.', async (): Promise<void> => {
+    class TokenInvalid extends defekt({ code: 'TokenInvalid' }) {}
+
+    const ex: unknown = 'some-arbitrary-value';
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
+    const assertIsCustomError = function (ex2: TokenInvalid): void {};
+
+    if (isCustomError(ex, TokenInvalid)) {
+      assertIsCustomError(ex);
+    }
+  });
+
+  test('acts as a type guard for specific custom errors with a set type for data.', async (): Promise<void> => {
+    class TokenInvalid extends defekt<string>({ code: 'TokenInvalid' }) {}
+
+    const ex: unknown = 'some-arbitrary-value';
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
+    const assertIsCustomError = function (ex2: TokenInvalid): void {};
+
+    if (isCustomError(ex, TokenInvalid)) {
+      assertIsCustomError(ex);
+    }
+  });
+
+  test('infers the type of the data attribute.', async (): Promise<void> => {
+    type Data = string;
+    class TokenInvalid extends defekt<Data>({ code: 'TokenInvalid' }) {}
+
+    const ex: unknown = 'some-arbitrary-value';
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
+    const assertIsData = function (data: Data | undefined): void {};
+
+    if (isCustomError(ex, TokenInvalid)) {
+      assertIsData(ex.data);
+    }
+  });
 });


### PR DESCRIPTION
This fixes a bug where `isCustomError` didn't correctly type guard custom errors when `unknown` was passed. `isCustomError` now also infers the type of `data` correctly.